### PR TITLE
trim expression prior to evaluation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ function evaluate(expression, context={}, options={}) {
   addContextToParser(parser, context);
 
   try {
-    return parser.evaluate(expression)
+    return parser.evaluate(expression.trim());
   } catch (e) {
     if (debug) {
       console.debug(e);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -51,6 +51,13 @@ describe("evaluate", async () => {
     assert.equal(evaluate(expression, BASE_CONTEXT()), "A IS LESS THAN B");
   });
 
+  it("should trim whitespace and not treat newline as array", () => {
+    const expression = `1
+    `;
+
+    assert.equal(evaluate(expression), 1);
+  });
+
   it("can use string concatenation along with functions", () => {
     const expression = `CONCATENATE("In 1 year are ", DAYS($values.dates_a.date_b.value, $values.dates_a.date_a.value) - 1, " days")`
 


### PR DESCRIPTION
![Screen Shot 2022-11-16 at 2 47 01 PM](https://user-images.githubusercontent.com/11606807/202279373-50b40b54-2cfc-49fa-970b-4e408a7e2524.png)

before fixing, what the failing test shows:

```
 failureType: 'testCodeFailure'
      error: |-
        ResultSet {
          entries: [
            1
          ]
        } == 1
      code: 'ERR_ASSERTION'
```