### PR TITLE
[huvrdata/huvr#6803] throw errors returned from formulajs, rather than rendering them in string

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -14,4 +14,27 @@ function EvaluationError(baseError) {
 // https://stackoverflow.com/questions/1382107/whats-a-good-way-to-extend-error-in-javascript/5251506#5251506
 EvaluationError.prototype = new Error;
 
-export { EvaluationError };
+/**
+ * @param {Function} formulaJSFunctionName function from formulajs lib (not using `formulaJSFunction.name` as it will likely be minified)
+ * @param {Function} formulaJSFunction function from formulajs lib
+ *
+ * @return {Function} function which will throw error, rather than return string
+ */
+function wrapFormulaJSFunctionsWithErrorContext(formulaJSFunctionName, formulaJSFunction) {
+  return function _wrappedFunction (...args) {
+
+    const result = formulaJSFunction(...args);
+
+    if (result instanceof Error) {
+      // see list of errors:
+      //  https://github.com/formulajs/formulajs/blob/master/src/utils/error.js
+      const error = result;
+      error.name = error.message;
+      error.message = `${error.message} ${formulaJSFunctionName} ${JSON.stringify(args)}`;
+      throw error;
+    }
+    return result;
+  }
+}
+
+export { EvaluationError , wrapFormulaJSFunctionsWithErrorContext };

--- a/src/errors.js
+++ b/src/errors.js
@@ -28,9 +28,9 @@ function wrapFormulaJSFunctionsWithErrorContext(formulaJSFunctionName, formulaJS
     if (result instanceof Error) {
       // see list of errors:
       //  https://github.com/formulajs/formulajs/blob/master/src/utils/error.js
-      const error = result;
-      error.name = error.message;
-      error.message = `${error.message} ${formulaJSFunctionName} ${JSON.stringify(args)}`;
+      const error = new Error();
+      error.name = result.message;
+      error.message = `${result.message} ${formulaJSFunctionName} ${JSON.stringify(args)}`;
       throw error;
     }
     return result;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import formulajs from "formulajs";
-import { EvaluationError } from "./errors.js";
+import { EvaluationError, wrapFormulaJSFunctionsWithErrorContext } from "./errors.js";
 import { limitedParser, addContextToParser } from "./parser.js";
 import * as customFunctions from "./functions.js";
 import { flattenContext } from "./utils.js";
@@ -28,7 +28,9 @@ function evaluate(expression, context={}, options={}) {
   // https://mathjs.org/docs/expressions/parsing.html#parser
   const parser = limitedParser();
 
-  addContextToParser(parser, formulajs);
+  for (const [name, func] of Object.entries(formulajs)) {
+    parser.set(name, wrapFormulaJSFunctionsWithErrorContext(name, func));
+  }
   addContextToParser(parser, customFunctions);
   addContextToParser(parser, context);
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -23,8 +23,8 @@ function addContextToParser(parser, context) {
   if (!context) {
     return;
   }
-  for (const [name, func] of Object.entries(context)) {
-    parser.set(name, func);
+  for (const [name, value] of Object.entries(context)) {
+    parser.set(name, value);
   }
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -63,7 +63,7 @@ describe("evaluate", async () => {
     const context = BASE_CONTEXT();
     context.$values.dates_a.date_a.value = "not a date"
 
-    assert.throws(() => evaluate(expression, context), { name: "EvaluationError", message: /unexpected type of argument/i });
+    assert.throws(() =>  evaluate(expression, context), { name: "EvaluationError", message: /VALUE.*DAYS/i });
   });
 
   it("should throw meaningful error if invalid context lookup", () => {


### PR DESCRIPTION
relates to https://github.com/huvrdata/huvr/issues/6803

Was getting a false positive,

formulajs simply returns the error object, rather than _throwing_ the error.

- wrap formulajs functions with function to add error context and throw error if returned

before:

```js
> f.DATE('bad/date') instanceof Error
true
> f.DATE('bad/date')
Error: #VALUE?
```

after:

```js
> try {
...   wrapFormulaJSFunctionsWithErrorContext("DATE", f.DATE)("bad/date")
... } catch (e) {
...   exc = e
... }
> exc
#VALUE?: #VALUE? DATE ["bad/date"]
    at _wrappedFunction (REPL16:9:21)
    at REPL22:2:57
    at Script.runInThisContext (node:vm:129:12)
    at REPLServer.defaultEval (node:repl:566:29)
    at bound (node:domain:421:15)
    at REPLServer.runBound [as eval] (node:domain:432:12)
    at REPLServer.onLine (node:repl:893:10)
    at REPLServer.emit (node:events:539:35)
    at REPLServer.emit (node:domain:475:12)
    at REPLServer.Interface._onLine (node:readline:487:10)
> exc.name
'#VALUE?'
> exc.message
'#VALUE? DATE ["bad/date"]'
```