### PR TITLE
docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ import { evaluate } from '@huvrdata/evaluate';
 const expression = `IF(
     SUM($values.a, $values.b) > $values.c,
     COALESCE($values.success_message, "success"),
-    COALESCE($values.failure_message, "failure"),
+    COALESCE($values.failure_message, "failure")
 )`
 const context = {
     $values: {
@@ -40,7 +40,7 @@ const context = {
         b: 4,
         c: 5,
         failure_message: "A + B < C",
-        failure_message: "A + B > C",
+        success_message: "A + B > C",
     },
 }
 


### PR DESCRIPTION
- Fixed `EvaluationError` that was caused by dangling comma at the end of the expression string.

```
   at async loadESM (node:internal/process/esm_loader:28:7)
    at async handleMainPromise (node:internal/modules/run_main:113:12) {
  name: 'EvaluationError',
  message: 'Unable to evaluate expression: Value expected (char 148)',
  type: 'SyntaxError',
  _baseError: SyntaxError: Value expected (char 148)
      at createSyntaxError (file:///project/workspace/node_modules/mathjs/lib/esm/expression/parse.js:1608:17)
      at parseEnd (file:///project/workspace/node_modules/mathjs/lib/esm/expression/parse.js:1575:13)
      at parseParentheses (file:///project/workspace/node_modules/mathjs/lib/esm/expression/parse.js:1562:12)
      at parseNumber (file:///project/workspace/node_modules/mathjs/lib/esm/expression/parse.js:1535:12)
      at parseObject (file:///project/workspace/node_modules/mathjs/lib/esm/expression/parse.js:1517:12)
      at parseMatrix (file:///project/workspace/node_modules/mathjs/lib/esm/expression/parse.js:1449:12)
      at parseString (file:///project/workspace/node_modules/mathjs/lib/esm/expression/parse.js:1343:12)
      at parseSymbol (file:///project/workspace/node_modules/mathjs/lib/esm/expression/parse.js:1241:12)
      at parseCustomNodes (file:///project/workspace/node_modules/mathjs/lib/esm/expression/parse.js:1214:12)
      at parseLeftHandOperators (file:///project/workspace/node_modules/mathjs/lib/esm/expression/parse.js:1138:12) {
    char: 148
  }
}
```

- Corrected the duplicate `failure_message` key in the context.