### PR TITLE
feat: new BADGE function

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -12,3 +12,11 @@ export function COALESCE(...args) {
     }
   }
 };
+
+/**
+ * Return the size on an array as text, with an optional given prefix
+ */
+export function BADGE(array, prefix = '') {
+  const length = array?.length || 0;
+  return `${prefix}${length}`;
+}

--- a/src/functions.js
+++ b/src/functions.js
@@ -14,9 +14,10 @@ export function COALESCE(...args) {
 };
 
 /**
- * Return the size on an array as text, with an optional given prefix
+ * Return the size on an array as text, with an optional given prefix/postfix
  */
-export function BADGE(array, prefix = '') {
+export function BADGE(array, prefix = '', postfix = '') {
   const length = array?.length || '';
-  return `${prefix}${length}`;
+  if (length) return `${prefix}${length}${postfix}`;
+  return '';
 }

--- a/src/functions.js
+++ b/src/functions.js
@@ -17,6 +17,6 @@ export function COALESCE(...args) {
  * Return the size on an array as text, with an optional given prefix
  */
 export function BADGE(array, prefix = '') {
-  const length = array?.length || 0;
+  const length = array?.length || '';
   return `${prefix}${length}`;
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -218,9 +218,9 @@ describe("badge", () => {
     };
     assert.equal(evaluate(expression, context), "2");
   });
-  it("should include the given prefix when provided", () => {
-    const expression = `BADGE($var,'count:')`;
+  it("should include the given prefix/postfix when provided", () => {
+    const expression = `BADGE($var,'count:[',']')`;
     const context = {$var: [100]};
-    assert.equal(evaluate(expression, context), "count:1");
+    assert.equal(evaluate(expression, context), "count:[1]");
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -194,15 +194,17 @@ describe("badge", () => {
     assert.equal(evaluate(expression, context2), "3");
     const context3 = {$var: 'hello'};
     assert.equal(evaluate(expression, context3), "5");
+    const context4 = {$var: {"a": "1", "b": "2"}};
+    assert.equal(evaluate(expression, context4), "");
   });
   it("should return 0 if the value is not an array or is empty or undefined", () => {
     const expression = `BADGE($var)`;
     const context = {$var: []};
-    assert.equal(evaluate(expression, context), "0");
+    assert.equal(evaluate(expression, context), "");
     const context2 = {$var: undefined};
-    assert.equal(evaluate(expression, context2), "0");
+    assert.equal(evaluate(expression, context2), "");
     const context3 = {$var: 1};
-    assert.equal(evaluate(expression, context3), "0");
+    assert.equal(evaluate(expression, context3), "");
   });
   it("should return the length of an array, which is populated with objects", () => {
     const expression = `BADGE($local.add_media__media)`;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,3 @@
-
 import { describe, it } from "node:test";
 import assert from "node:assert";
 
@@ -183,5 +182,43 @@ describe("flattenContext", () => {
         a_0__b_1__c_3: 25,
       },
     )
-  })
+  });
+});
+
+describe("badge", () => {
+  it("should return the length of an array or string", () => {
+    const expression = `BADGE($var)`;
+    const context = {$var: [100]};
+    assert.equal(evaluate(expression, context), "1");
+    const context2 = {$var: [1,2,3]};
+    assert.equal(evaluate(expression, context2), "3");
+    const context3 = {$var: 'hello'};
+    assert.equal(evaluate(expression, context3), "5");
+  });
+  it("should return 0 if the value is not an array or is empty or undefined", () => {
+    const expression = `BADGE($var)`;
+    const context = {$var: []};
+    assert.equal(evaluate(expression, context), "0");
+    const context2 = {$var: undefined};
+    assert.equal(evaluate(expression, context2), "0");
+    const context3 = {$var: 1};
+    assert.equal(evaluate(expression, context3), "0");
+  });
+  it("should return the length of an array, which is populated with objects", () => {
+    const expression = `BADGE($local.add_media__media)`;
+    const context = {
+      $local: {
+        add_media__media: [
+          { id: 1, name: "a" },
+          { id: 2, name: { abc: 1 }},
+        ]
+      }
+    };
+    assert.equal(evaluate(expression, context), "2");
+  });
+  it("should include the given prefix when provided", () => {
+    const expression = `BADGE($var,'count:')`;
+    const context = {$var: [100]};
+    assert.equal(evaluate(expression, context), "count:1");
+  });
 });


### PR DESCRIPTION
The badge function provides an easy way to get the length of a variable (usually an array), and include an optional text prefix, such as `media: 4` when counting number of media objects. It needs to handle empty and undefined values as well without erroring