### PR TITLE
fix: update github actions to build correct distribution 

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,6 +28,7 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org/
       - run: npm ci
+      - run: npm run build
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "dist/evaluate.mjs",
   "scripts": {
     "test": "node --trace-uncaught ./test/index.test.js",
-    "build": "rollup --config rollup.config.js",
+    "build": "npx rollup --config rollup.config.js",
     "dist": "npm run test && npm run build",
     "release": "np --no-tests"
   },  

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "main": "dist/evaluate.js",
   "module": "dist/evaluate.mjs",
   "scripts": {
-    "build": "make build",
-    "dist": "make dist",
-    "release": "make release",
-    "test": "make test"
-  },
+    "test": "node --trace-uncaught ./test/index.test.js",
+    "build": "rollup --config rollup.config.js",
+    "dist": "npm run test && npm run build",
+    "release": "np --no-tests"
+  },  
   "files": [
     "README.md",
     "LICENSE",


### PR DESCRIPTION
#23 

- in `package.json` scripts: replaces the make commands 
- in `npm-publish.yml`: adds `npm run build` to build distribution before publishing 